### PR TITLE
Use built in json parser

### DIFF
--- a/lib/coinmetrics.js
+++ b/lib/coinmetrics.js
@@ -6,7 +6,7 @@ const GET_AVAILABLE_DATA_TYPE_FOR_ASSET = 'get_available_data_types_for_asset'
 
 module.exports.getSupportedAssets = async(cb) => {
   var url = COINMETRICS_API_URL + GET_SUPPORTED_ASSETS
-  var results = JSON.parse(await rp(url))
+  var results = await rp(url, {json: true})
   if (cb) {
     cb(results)
   } else {
@@ -16,7 +16,7 @@ module.exports.getSupportedAssets = async(cb) => {
 
 module.exports.getAvailableDataTypesForAsset = async(asset, cb) => {
   var url = COINMETRICS_API_URL + GET_AVAILABLE_DATA_TYPE_FOR_ASSET + '/' + asset
-  var results = JSON.parse(await rp(url))
+  var results = await rp(url, {json: true});
   if (cb) {
     cb(results)
   } else {
@@ -26,7 +26,7 @@ module.exports.getAvailableDataTypesForAsset = async(asset, cb) => {
 
 module.exports.getAssetDataForTimeRange = async(asset, data_type, begin_timestamp, end_timestamp, cb) => {
   var url = COINMETRICS_API_URL + GET_ASSET_DATA_FOR_TIME_RANGE + asset + '/' + data_type + '/' + begin_timestamp + '/' + end_timestamp
-  var results = JSON.parse(await rp(url))
+  var results = await rp(url, {json: true})
   if (cb) {
     cb(results)
   } else {


### PR DESCRIPTION
This provides slightly better error handling in the event a non json body is returned by the api, which can happen on occasion.